### PR TITLE
Fix translate blur

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -178,7 +178,7 @@ class PinchZoomPan extends React.Component<PZPProps, PZPState> {
 
   render() {
     const { x, y, z } = this.state.transform;
-    const transform = `translate(${x}px, ${y}px) scale(${z})`;
+    const transform = `translate(${Math.round(x)}px, ${Math.round(y)}px) scale(${z})`;
     return (
       <div
         ref={this.setRoot}


### PR DESCRIPTION
Depending on element size and move position, the `x` and `y` values in `translate` can be set to fractions of a pixel. This causes the content to appear blurry, even with `scale(1)`. Rounding `x` and `y` to the nearest whole pixel value to avoid this issue.

With `.5` `x` and `y` values.
![image](https://user-images.githubusercontent.com/8342105/69104228-c2b49c80-0abb-11ea-9203-8301c2db18e9.png)

With `.0` `x` and `y` values (using `Math.round()`)
![image](https://user-images.githubusercontent.com/8342105/69104245-d3651280-0abb-11ea-8e84-f35400a25754.png)
